### PR TITLE
generate_ptable.sh: support 8GB eMMC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,14 @@ l-loader.bin: start.S debug.S
 	$(LD) -Bstatic -Tl-loader.lds -Ttext 0xf9800800 start.o debug.o -o loader
 	$(OBJCOPY) -O binary loader temp
 	python gen_loader.py -o l-loader.bin --img_loader=temp --img_bl1=bl1.bin
-	sudo PTABLE=aosp bash -x generate_ptable.sh
-	python gen_loader.py -o ptable-aosp.img --img_prm_ptable=prm_ptable.img
-	sudo PTABLE=linux bash -x generate_ptable.sh
-	python gen_loader.py -o ptable-linux.img --img_prm_ptable=prm_ptable.img
+	sudo PTABLE=aosp-4G bash -x generate_ptable.sh
+	python gen_loader.py -o ptable-aosp-4G.img --img_prm_ptable=prm_ptable.img
+	sudo PTABLE=linux-4G bash -x generate_ptable.sh
+	python gen_loader.py -o ptable-linux-4G.img --img_prm_ptable=prm_ptable.img
+	sudo PTABLE=aosp-8G bash -x generate_ptable.sh
+	python gen_loader.py -o ptable-aosp-8G.img --img_prm_ptable=prm_ptable.img
+	sudo PTABLE=linux-8G bash -x generate_ptable.sh
+	python gen_loader.py -o ptable-linux-8G.img --img_prm_ptable=prm_ptable.img
 
 clean:
 	rm -f *.o loader l-loader.bin temp

--- a/generate_ptable.sh
+++ b/generate_ptable.sh
@@ -13,8 +13,11 @@ case ${PTABLE} in
   tiny)
     SECTOR_NUMBER=81920
     ;;
-  aosp|linux)
+  aosp-4G|linux-4G)
     SECTOR_NUMBER=7471104
+    ;;
+  aosp-8G|linux-8G)
+    SECTOR_NUMBER=15269888
     ;;
 esac
 
@@ -29,7 +32,7 @@ case ${PTABLE} in
     sgdisk -n 1:2048:4095 -t 1:0700 -u 1:F9F21F01-A8D4-5F0E-9746-594869AEC3E4 -c 1:"vrl" -p ${TEMP_FILE}
     sgdisk -n 2:4096:6143 -t 2:0700 -u 2:F9F21F02-A8D4-5F04-9746-594869AEC3E4 -c 2:"vrl_backup" -p ${TEMP_FILE}
     ;;
-  aosp)
+  aosp*)
     dd if=/dev/zero of=${TEMP_FILE} bs=${SECTOR_SIZE} count=${SECTOR_NUMBER}
     sgdisk -U 2CB85345-6A91-4043-8203-723F0D28FBE8 -v ${TEMP_FILE}
     #[1: vrl: 1M-2M]
@@ -53,7 +56,7 @@ case ${PTABLE} in
     #[10: userdata: 2126M-End]
     sgdisk -n -E -t 10:8300 -u 10:064111F6-463B-4CE1-876B-13F3684CE164 -c 10:"userdata" -p ${TEMP_FILE}
     ;;
-  linux)
+  linux*)
     dd if=/dev/zero of=${TEMP_FILE} bs=${SECTOR_SIZE} count=${SECTOR_NUMBER}
     sgdisk -U 2CB85345-6A91-4043-8203-723F0D28FBE8 -v ${TEMP_FILE}
     #[1: vrl: 1M-2M]


### PR DESCRIPTION
Now there're three kinds of eMMC capacity size in HiKey. They're
3.56GB, 3.6GB & 7.28GB.

So we have to provide 4 different partition tables.
aosp-4G -- AOSP partition table for both 3.56GB and 3.6GB eMMC.
aosp-8G -- AOSP partition table for 7.28GB eMMC.
linux-4G -- Debian partition table for both 3.56GB and 3.6GB eMMC.
linux-8G -- Debian partition table for 7.28GB eMMC.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
